### PR TITLE
Fix spans sometimes not closing on the same line

### DIFF
--- a/src/components/code-highlight/code-highlight.tsx
+++ b/src/components/code-highlight/code-highlight.tsx
@@ -167,7 +167,6 @@ export class CodeHighlight {
               break;
           }
       }
-      //console.log(line);
       let lineIndex = this.lines.findIndex(l => l.index === index);
       if (lineIndex > -1) {
         const lineType = this.lines[lineIndex].type;

--- a/src/components/code-highlight/code-highlight.tsx
+++ b/src/components/code-highlight/code-highlight.tsx
@@ -152,7 +152,22 @@ export class CodeHighlight {
     }
 
     let lastType = "-";
+    let openSpan = ""
     this.highlight = this.highlight.split('\n').map((line, index) => {
+      if (openSpan !== "") {
+          line = openSpan + line;
+          openSpan = "";
+      }
+
+      const spanTags = line.match(/<span class="[^"]*">|<\/span>/g) || [];
+      for (let i = spanTags.length - 1; i >= 0; i--) {
+          if (!spanTags[i].endsWith('</span>')) {
+              openSpan = spanTags[i];
+              line += '</span>';
+              break;
+          }
+      }
+      //console.log(line);
       let lineIndex = this.lines.findIndex(l => l.index === index);
       if (lineIndex > -1) {
         const lineType = this.lines[lineIndex].type;


### PR DESCRIPTION
Fixes an issue when for some highlighted languages the spans would not close on the split lines causing a visual glitch and incorrect addition handling. See pictures.
Before the fix:

<img width="500" alt="image" src="https://github.com/milung/wac-book-builder/assets/99325737/9ec4712b-66a3-40ea-86bd-68c96ef221de">

After the fix:
<img width="500" alt="image" src="https://github.com/milung/wac-book-builder/assets/99325737/8c035211-ee79-4ac5-b3de-0e1b3ff87d9d">
